### PR TITLE
Roll up all previous changes in KyleKun's video_trimmer

### DIFF
--- a/example/lib/trimmer_view.dart
+++ b/example/lib/trimmer_view.dart
@@ -88,6 +88,7 @@ class _TrimmerViewState extends State<TrimmerView> {
                     child: TrimViewer(
                       trimmer: _trimmer,
                       viewerHeight: 50.0,
+                      type: ViewerType.fixed,
                       viewerWidth: MediaQuery.of(context).size.width,
                       durationStyle: DurationStyle.FORMAT_MM_SS,
                       maxVideoLength: const Duration(seconds: 10),

--- a/example/lib/trimmer_view.dart
+++ b/example/lib/trimmer_view.dart
@@ -89,7 +89,6 @@ class _TrimmerViewState extends State<TrimmerView> {
                       trimmer: _trimmer,
                       viewerHeight: 50.0,
                       type: ViewerType.fixed,
-                      viewerWidth: MediaQuery.of(context).size.width,
                       durationStyle: DurationStyle.FORMAT_MM_SS,
                       maxVideoLength: const Duration(seconds: 10),
                       editorProperties: TrimEditorProperties(

--- a/lib/src/trim_viewer/fixed_viewer/fixed_thumbnail_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_thumbnail_viewer.dart
@@ -45,7 +45,7 @@ class FixedThumbnailViewer extends StatelessWidget {
     required this.numberOfThumbnails,
     required this.fit,
     required this.onThumbnailLoadingComplete,
-    this.quality = 75,
+    this.quality = 7,
   });
 
   @override

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -341,10 +341,14 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
   void _onDragUpdate(DragUpdateDetails details) {
     if (!_allowDrag) return;
 
+    final double newStartPos = _startPos.dx + details.delta.dx;
+    final double newEndPos = _endPos.dx + details.delta.dx;
+
     if (_dragType == EditorDragType.left) {
       _startCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_startPos.dx + details.delta.dx >= 0) &&
-          (_startPos.dx + details.delta.dx <= _endPos.dx) &&
+      if ((_endPos.dx - newStartPos >= 1000) &&
+          (newStartPos >= 0) &&
+          (newStartPos <= _endPos.dx) &&
           !(_endPos.dx - _startPos.dx - details.delta.dx > maxLengthPixels!)) {
         _startPos += details.delta;
         _onStartDragged();
@@ -352,8 +356,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
     } else if (_dragType == EditorDragType.center) {
       _startCircleSize = widget.editorProperties.circleSizeOnDrag;
       _endCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_startPos.dx + details.delta.dx >= 0) &&
-          (_endPos.dx + details.delta.dx <= _thumbnailViewerW)) {
+      if ((newStartPos >= 0) && (newEndPos <= _thumbnailViewerW)) {
         _startPos += details.delta;
         _endPos += details.delta;
         _onStartDragged();
@@ -361,8 +364,9 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
       }
     } else {
       _endCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_endPos.dx + details.delta.dx <= _thumbnailViewerW) &&
-          (_endPos.dx + details.delta.dx >= _startPos.dx) &&
+      if ((newEndPos - _startPos.dx >= 1000) &&
+          (newEndPos <= _thumbnailViewerW) &&
+          (newEndPos >= _startPos.dx) &&
           !(_endPos.dx - _startPos.dx + details.delta.dx > maxLengthPixels!)) {
         _endPos += details.delta;
         _onEndDragged();

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -433,23 +433,13 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
                   child: Padding(
                     padding: const EdgeInsets.only(bottom: 8.0),
                     child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       mainAxisSize: MainAxisSize.max,
                       children: <Widget>[
                         Text(
-                          Duration(milliseconds: _videoStartPos.toInt())
-                              .format(widget.durationStyle),
-                          style: widget.durationTextStyle,
-                        ),
-                        videoPlayerController.value.isPlaying
-                            ? Text(
-                                Duration(milliseconds: _currentPosition.toInt())
-                                    .format(widget.durationStyle),
-                                style: widget.durationTextStyle,
-                              )
-                            : Container(),
-                        Text(
-                          Duration(milliseconds: _videoEndPos.toInt())
+                          Duration(
+                                  milliseconds: _videoEndPos.toInt() -
+                                      _videoStartPos.toInt())
                               .format(widget.durationStyle),
                           style: widget.durationTextStyle,
                         ),

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -346,7 +346,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
 
     if (_dragType == EditorDragType.left) {
       _startCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_endPos.dx - newStartPos >= 1000) &&
+      if ((_endPos.dx - newStartPos >= 100) &&
           (newStartPos >= 0) &&
           (newStartPos <= _endPos.dx) &&
           !(_endPos.dx - _startPos.dx - details.delta.dx > maxLengthPixels!)) {
@@ -364,7 +364,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
       }
     } else {
       _endCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((newEndPos - _startPos.dx >= 1000) &&
+      if ((newEndPos - _startPos.dx >= 100) &&
           (newEndPos <= _thumbnailViewerW) &&
           (newEndPos >= _startPos.dx) &&
           !(_endPos.dx - _startPos.dx + details.delta.dx > maxLengthPixels!)) {

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -223,20 +223,22 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
         this.thumbnailWidget = thumbnailWidget;
         Duration totalDuration = videoPlayerController.value.duration;
 
-        if (widget.maxVideoLength > const Duration(milliseconds: 0) &&
-            widget.maxVideoLength < totalDuration) {
-          if (widget.maxVideoLength < totalDuration) {
-            minFraction = widget.minVideoLength.inMilliseconds /
-                totalDuration.inMilliseconds;
-            fraction = widget.maxVideoLength.inMilliseconds /
-                totalDuration.inMilliseconds;
-
-            minLengthPixels = _thumbnailViewerW * minFraction!;
-            maxLengthPixels = _thumbnailViewerW * fraction!;
-          }
-        } else {
+        if (totalDuration.inMilliseconds <= 1500) {
           maxLengthPixels = _thumbnailViewerW;
-          minLengthPixels = widget.minVideoLength.inMilliseconds.toDouble();
+          minLengthPixels = _thumbnailViewerW;
+        } else if (widget.maxVideoLength > const Duration(milliseconds: 0) &&
+            widget.maxVideoLength < totalDuration) {
+          minFraction = widget.minVideoLength.inMilliseconds /
+              totalDuration.inMilliseconds;
+          fraction = widget.maxVideoLength.inMilliseconds /
+              totalDuration.inMilliseconds;
+          minLengthPixels = _thumbnailViewerW * minFraction!;
+          maxLengthPixels = _thumbnailViewerW * fraction!;
+        } else {
+          minFraction = widget.minVideoLength.inMilliseconds /
+              totalDuration.inMilliseconds;
+          maxLengthPixels = _thumbnailViewerW;
+          minLengthPixels = _thumbnailViewerW * minFraction!;
         }
 
         _videoEndPos = fraction != null

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -330,8 +330,8 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
     final sideTapSize = widget.editorProperties.sideTapSize;
     debugPrint('SideTapSize: $sideTapSize');
 
-    final startDifference = (tapDx * 0.92) - _startPos.dx;
-    final endDifference = (tapDx * 0.92) - _endPos.dx;
+    final startDifference = (tapDx * 0.94) - _startPos.dx;
+    final endDifference = (tapDx * 0.94) - _endPos.dx;
     debugPrint('StartDiff: $startDifference');
     debugPrint('EndDiff: $endDifference');
 

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -325,32 +325,22 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
     debugPrint((_startPos.dx - details.localPosition.dx).abs().toString());
     debugPrint((_endPos.dx - details.localPosition.dx).abs().toString());
 
-    final startDifference = _startPos.dx - details.localPosition.dx;
-    final endDifference = _endPos.dx - details.localPosition.dx;
+    final startDifference = details.localPosition.dx - _startPos.dx;
+    final endDifference = details.localPosition.dx - _endPos.dx;
 
-    // First we determine whether the dragging motion should be allowed. The allowed
-    // zone is widget.sideTapSize (left) + frame (center) + widget.sideTapSize (right)
-    if (startDifference <= widget.editorProperties.sideTapSize &&
-        endDifference >= -widget.editorProperties.sideTapSize) {
+    // Determine which part is dragged
+    if (startDifference.abs() <= widget.editorProperties.sideTapSize) {
+      _dragType = EditorDragType.left;
+      _allowDrag = true;
+      _isCenterDrag = false;
+    } else if (endDifference.abs() <= widget.editorProperties.sideTapSize) {
+      _dragType = EditorDragType.right;
       _allowDrag = true;
       _isCenterDrag = false;
     } else {
-      debugPrint("Dragging is outside of frame, applying center drag");
-      _isCenterDrag = true;
+      _dragType = EditorDragType.center;
       _allowDrag = true;
-    }
-
-    // Now we determine which part is dragged
-    if (_isCenterDrag) {
-      _dragType = EditorDragType.center;
-    } else if (details.localPosition.dx <=
-        _startPos.dx + widget.editorProperties.sideTapSize) {
-      _dragType = EditorDragType.left;
-    } else if (details.localPosition.dx <=
-        _endPos.dx - widget.editorProperties.sideTapSize) {
-      _dragType = EditorDragType.center;
-    } else {
-      _dragType = EditorDragType.right;
+      _isCenterDrag = true;
     }
   }
 

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -512,56 +512,155 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
             physics: const BouncingScrollPhysics(),
             child: Row(
               children: [
-                for (int i = 1; i < quickCutNumber + 1; i++)
-                  Padding(
-                    padding: const EdgeInsets.all(10.0),
-                    child: TextButton.icon(
-                      style: ButtonStyle(
-                        foregroundColor: MaterialStateProperty.all<Color>(
-                          widget.editorProperties.quickCutForegroundColor,
-                        ),
-                        backgroundColor: MaterialStateProperty.all<Color>(
-                          widget.editorProperties.quickCutBackgroundColor,
-                        ),
-                        overlayColor: MaterialStateProperty.all<Color>(
-                          widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
-                        ),
-                        shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                          RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(35.0),
-                          ),
-                        ),
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: TextButton.icon(
+                    style: ButtonStyle(
+                      foregroundColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutForegroundColor,
                       ),
-                      icon: Icon(
-                        widget.editorProperties.quickCutIcon,
-                        size: widget.editorProperties.quickCutIconSize,
+                      backgroundColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutBackgroundColor,
                       ),
-                      onPressed: () {
-                        _startPos = const Offset(0, 0);
-                        _startFraction = 0.0;
-                        _videoStartPos = 0.0;
-                        _currentPosition = 0;
-                        _linearTween.begin = _startPos.dx;
-
-                        widget.onChangeStart!(_videoStartPos);
-                        videoPlayerController.seekTo(const Duration(milliseconds: 0));
-
-                        _endFraction = (i * 1000) / _videoDuration;
-                        _videoEndPos = _videoDuration * _endFraction;
-                        _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
-                        _linearTween.end = _endPos.dx;
-                        widget.onChangeEnd!(_videoEndPos);
-
-                        _animationController!.duration =
-                            Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
-                        _animationController!.reset();
-                      },
-                      label: Text(
-                        i.toString(),
-                        style: TextStyle(color: widget.editorProperties.quickCutTextColor),
+                      overlayColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
+                      ),
+                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                        RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(35.0),
+                        ),
                       ),
                     ),
+                    icon: Icon(
+                      widget.editorProperties.quickCutIcon,
+                      size: widget.editorProperties.quickCutIconSize,
+                    ),
+                    onPressed: () {
+                      _startPos = const Offset(0, 0);
+                      _startFraction = 0.0;
+                      _videoStartPos = 0.0;
+                      _currentPosition = 0;
+                      _linearTween.begin = _startPos.dx;
+
+                      widget.onChangeStart!(_videoStartPos);
+                      videoPlayerController.seekTo(const Duration(milliseconds: 0));
+
+                      _endFraction = (1 * 1000) / _videoDuration;
+                      _videoEndPos = _videoDuration * _endFraction;
+                      _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
+                      _linearTween.end = _endPos.dx;
+                      widget.onChangeEnd!(_videoEndPos);
+
+                      _animationController!.duration =
+                          Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
+                      _animationController!.reset();
+                    },
+                    label: Text(
+                      "1",
+                      style: TextStyle(color: widget.editorProperties.quickCutTextColor),
+                    ),
                   ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: TextButton.icon(
+                    style: ButtonStyle(
+                      foregroundColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutForegroundColor,
+                      ),
+                      backgroundColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutBackgroundColor,
+                      ),
+                      overlayColor: MaterialStateProperty.all<Color>(
+                        widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
+                      ),
+                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                        RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(35.0),
+                        ),
+                      ),
+                    ),
+                    icon: Icon(
+                      widget.editorProperties.quickCutIcon,
+                      size: widget.editorProperties.quickCutIconSize,
+                    ),
+                    onPressed: () {
+                      _startPos = const Offset(0, 0);
+                      _startFraction = 0.0;
+                      _videoStartPos = 0.0;
+                      _currentPosition = 0;
+                      _linearTween.begin = _startPos.dx;
+
+                      widget.onChangeStart!(_videoStartPos);
+                      videoPlayerController.seekTo(const Duration(milliseconds: 0));
+
+                      _endFraction = (1.5 * 1000) / _videoDuration;
+                      _videoEndPos = _videoDuration * _endFraction;
+                      _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
+                      _linearTween.end = _endPos.dx;
+                      widget.onChangeEnd!(_videoEndPos);
+
+                      _animationController!.duration =
+                          Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
+                      _animationController!.reset();
+                    },
+                    label: Text(
+                      "1.5",
+                      style: TextStyle(color: widget.editorProperties.quickCutTextColor),
+                    ),
+                  ),
+                ),
+
+                // for (int i = 1; i < quickCutNumber + 1; i++)
+                //   Padding(
+                //     padding: const EdgeInsets.all(10.0),
+                //     child: TextButton.icon(
+                //       style: ButtonStyle(
+                //         foregroundColor: MaterialStateProperty.all<Color>(
+                //           widget.editorProperties.quickCutForegroundColor,
+                //         ),
+                //         backgroundColor: MaterialStateProperty.all<Color>(
+                //           widget.editorProperties.quickCutBackgroundColor,
+                //         ),
+                //         overlayColor: MaterialStateProperty.all<Color>(
+                //           widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
+                //         ),
+                //         shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                //           RoundedRectangleBorder(
+                //             borderRadius: BorderRadius.circular(35.0),
+                //           ),
+                //         ),
+                //       ),
+                //       icon: Icon(
+                //         widget.editorProperties.quickCutIcon,
+                //         size: widget.editorProperties.quickCutIconSize,
+                //       ),
+                //       onPressed: () {
+                //         _startPos = const Offset(0, 0);
+                //         _startFraction = 0.0;
+                //         _videoStartPos = 0.0;
+                //         _currentPosition = 0;
+                //         _linearTween.begin = _startPos.dx;
+                //
+                //         widget.onChangeStart!(_videoStartPos);
+                //         videoPlayerController.seekTo(const Duration(milliseconds: 0));
+                //
+                //         _endFraction = (i * 1000) / _videoDuration;
+                //         _videoEndPos = _videoDuration * _endFraction;
+                //         _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
+                //         _linearTween.end = _endPos.dx;
+                //         widget.onChangeEnd!(_videoEndPos);
+                //
+                //         _animationController!.duration =
+                //             Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
+                //         _animationController!.reset();
+                //       },
+                //       label: Text(
+                //         i.toString(),
+                //         style: TextStyle(color: widget.editorProperties.quickCutTextColor),
+                //       ),
+                //     ),
+                //   ),
               ],
             ),
           ),

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -174,7 +174,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
   AnimationController? _animationController;
   late Tween<double> _linearTween;
 
-  int quickCutNumber = 1;
+  List<double> quickCutNumber = [1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
   /// Quick access to VideoPlayerController, only not null after [TrimmerEvent.initialized]
   /// has been emitted.
@@ -313,7 +313,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
 
       videoPlayerController.setVolume(1.0);
       _videoDuration = videoPlayerController.value.duration.inMilliseconds;
-      quickCutNumber = (_videoDuration ~/ 1000).clamp(1, 10);
+      //quickCutNumber = (_videoDuration ~/ 1000).clamp(1, 10);
     }
   }
 
@@ -512,155 +512,57 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
             physics: const BouncingScrollPhysics(),
             child: Row(
               children: [
-                Padding(
-                  padding: const EdgeInsets.all(10.0),
-                  child: TextButton.icon(
-                    style: ButtonStyle(
-                      foregroundColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutForegroundColor,
-                      ),
-                      backgroundColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutBackgroundColor,
-                      ),
-                      overlayColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
-                      ),
-                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(35.0),
+                for (double i in quickCutNumber)
+                  if (i <= (_videoDuration ~/ 1000))
+                    Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: TextButton.icon(
+                        style: ButtonStyle(
+                          foregroundColor: MaterialStateProperty.all<Color>(
+                            widget.editorProperties.quickCutForegroundColor,
+                          ),
+                          backgroundColor: MaterialStateProperty.all<Color>(
+                            widget.editorProperties.quickCutBackgroundColor,
+                          ),
+                          overlayColor: MaterialStateProperty.all<Color>(
+                            widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
+                          ),
+                          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                            RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(35.0),
+                            ),
+                          ),
+                        ),
+                        icon: Icon(
+                          widget.editorProperties.quickCutIcon,
+                          size: widget.editorProperties.quickCutIconSize,
+                        ),
+                        onPressed: () {
+                          _startPos = const Offset(0, 0);
+                          _startFraction = 0.0;
+                          _videoStartPos = 0.0;
+                          _currentPosition = 0;
+                          _linearTween.begin = _startPos.dx;
+
+                          widget.onChangeStart!(_videoStartPos);
+                          videoPlayerController.seekTo(const Duration(milliseconds: 0));
+
+                          _endFraction = (i * 1000) / _videoDuration;
+                          _videoEndPos = _videoDuration * _endFraction;
+                          _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
+                          _linearTween.end = _endPos.dx;
+                          widget.onChangeEnd!(_videoEndPos);
+
+                          _animationController!.duration =
+                              Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
+                          _animationController!.reset();
+                        },
+                        label: Text(
+                          (i == i.roundToDouble()?i.round():i).toString(),
+                          style: TextStyle(color: widget.editorProperties.quickCutTextColor),
                         ),
                       ),
                     ),
-                    icon: Icon(
-                      widget.editorProperties.quickCutIcon,
-                      size: widget.editorProperties.quickCutIconSize,
-                    ),
-                    onPressed: () {
-                      _startPos = const Offset(0, 0);
-                      _startFraction = 0.0;
-                      _videoStartPos = 0.0;
-                      _currentPosition = 0;
-                      _linearTween.begin = _startPos.dx;
-
-                      widget.onChangeStart!(_videoStartPos);
-                      videoPlayerController.seekTo(const Duration(milliseconds: 0));
-
-                      _endFraction = (1 * 1000) / _videoDuration;
-                      _videoEndPos = _videoDuration * _endFraction;
-                      _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
-                      _linearTween.end = _endPos.dx;
-                      widget.onChangeEnd!(_videoEndPos);
-
-                      _animationController!.duration =
-                          Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
-                      _animationController!.reset();
-                    },
-                    label: Text(
-                      "1",
-                      style: TextStyle(color: widget.editorProperties.quickCutTextColor),
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(10.0),
-                  child: TextButton.icon(
-                    style: ButtonStyle(
-                      foregroundColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutForegroundColor,
-                      ),
-                      backgroundColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutBackgroundColor,
-                      ),
-                      overlayColor: MaterialStateProperty.all<Color>(
-                        widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
-                      ),
-                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(35.0),
-                        ),
-                      ),
-                    ),
-                    icon: Icon(
-                      widget.editorProperties.quickCutIcon,
-                      size: widget.editorProperties.quickCutIconSize,
-                    ),
-                    onPressed: () {
-                      _startPos = const Offset(0, 0);
-                      _startFraction = 0.0;
-                      _videoStartPos = 0.0;
-                      _currentPosition = 0;
-                      _linearTween.begin = _startPos.dx;
-
-                      widget.onChangeStart!(_videoStartPos);
-                      videoPlayerController.seekTo(const Duration(milliseconds: 0));
-
-                      _endFraction = (1.5 * 1000) / _videoDuration;
-                      _videoEndPos = _videoDuration * _endFraction;
-                      _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
-                      _linearTween.end = _endPos.dx;
-                      widget.onChangeEnd!(_videoEndPos);
-
-                      _animationController!.duration =
-                          Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
-                      _animationController!.reset();
-                    },
-                    label: Text(
-                      "1.5",
-                      style: TextStyle(color: widget.editorProperties.quickCutTextColor),
-                    ),
-                  ),
-                ),
-
-                // for (int i = 1; i < quickCutNumber + 1; i++)
-                //   Padding(
-                //     padding: const EdgeInsets.all(10.0),
-                //     child: TextButton.icon(
-                //       style: ButtonStyle(
-                //         foregroundColor: MaterialStateProperty.all<Color>(
-                //           widget.editorProperties.quickCutForegroundColor,
-                //         ),
-                //         backgroundColor: MaterialStateProperty.all<Color>(
-                //           widget.editorProperties.quickCutBackgroundColor,
-                //         ),
-                //         overlayColor: MaterialStateProperty.all<Color>(
-                //           widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
-                //         ),
-                //         shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                //           RoundedRectangleBorder(
-                //             borderRadius: BorderRadius.circular(35.0),
-                //           ),
-                //         ),
-                //       ),
-                //       icon: Icon(
-                //         widget.editorProperties.quickCutIcon,
-                //         size: widget.editorProperties.quickCutIconSize,
-                //       ),
-                //       onPressed: () {
-                //         _startPos = const Offset(0, 0);
-                //         _startFraction = 0.0;
-                //         _videoStartPos = 0.0;
-                //         _currentPosition = 0;
-                //         _linearTween.begin = _startPos.dx;
-                //
-                //         widget.onChangeStart!(_videoStartPos);
-                //         videoPlayerController.seekTo(const Duration(milliseconds: 0));
-                //
-                //         _endFraction = (i * 1000) / _videoDuration;
-                //         _videoEndPos = _videoDuration * _endFraction;
-                //         _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
-                //         _linearTween.end = _endPos.dx;
-                //         widget.onChangeEnd!(_videoEndPos);
-                //
-                //         _animationController!.duration =
-                //             Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
-                //         _animationController!.reset();
-                //       },
-                //       label: Text(
-                //         i.toString(),
-                //         style: TextStyle(color: widget.editorProperties.quickCutTextColor),
-                //       ),
-                //     ),
-                //   ),
               ],
             ),
           ),

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -321,19 +321,35 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
   /// Determine which [EditorDragType] is used.
   void _onDragStart(DragStartDetails details) {
     debugPrint("_onDragStart");
-    debugPrint(details.localPosition.toString());
-    debugPrint((_startPos.dx - details.localPosition.dx).abs().toString());
-    debugPrint((_endPos.dx - details.localPosition.dx).abs().toString());
+    debugPrint('StartPos: ${_startPos.dx}');
+    debugPrint('EndPos: ${_endPos.dx}');
 
-    final startDifference = details.localPosition.dx - _startPos.dx;
-    final endDifference = details.localPosition.dx - _endPos.dx;
+    final tapDx = details.localPosition.dx;
+    debugPrint('TapDx: $tapDx');
+
+    final sideTapSize = widget.editorProperties.sideTapSize;
+    debugPrint('SideTapSize: $sideTapSize');
+
+    final startDifference = (tapDx * 0.92) - _startPos.dx;
+    final endDifference = (tapDx * 0.92) - _endPos.dx;
+    debugPrint('StartDiff: $startDifference');
+    debugPrint('EndDiff: $endDifference');
+
+    // Left range
+    final startIsWithinLeftRange = startDifference.abs() <= sideTapSize;
+    final endIsWithinLeftRange = endDifference.abs() <= sideTapSize;
+
+    // Right range
+    final startIsWithinRightRange =
+        tapDx >= _startPos.dx && tapDx <= _startPos.dx + sideTapSize * 1.75;
+    final endIsWithinRightRange = tapDx >= _endPos.dx && tapDx <= _endPos.dx + sideTapSize * 1.75;
 
     // Determine which part is dragged
-    if (startDifference.abs() <= widget.editorProperties.sideTapSize) {
+    if (startIsWithinLeftRange || startIsWithinRightRange) {
       _dragType = EditorDragType.left;
       _allowDrag = true;
       _isCenterDrag = false;
-    } else if (endDifference.abs() <= widget.editorProperties.sideTapSize) {
+    } else if (endIsWithinLeftRange || endIsWithinRightRange) {
       _dragType = EditorDragType.right;
       _allowDrag = true;
       _isCenterDrag = false;

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -174,6 +174,8 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
   AnimationController? _animationController;
   late Tween<double> _linearTween;
 
+  int quickCutNumber = 1;
+
   /// Quick access to VideoPlayerController, only not null after [TrimmerEvent.initialized]
   /// has been emitted.
   VideoPlayerController get videoPlayerController =>
@@ -311,6 +313,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
 
       videoPlayerController.setVolume(1.0);
       _videoDuration = videoPlayerController.value.duration.inMilliseconds;
+      quickCutNumber = (_videoDuration ~/ 1000).clamp(1, 10);
     }
   }
 
@@ -494,6 +497,66 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
                     : _thumbnailViewerW,
                 child: thumbnailWidget ?? Container(),
               ),
+            ),
+          ),
+
+          /// Quick Cut Buttons
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            child: Row(
+              children: [
+                for (int i = 1; i < quickCutNumber + 1; i++)
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: TextButton.icon(
+                      style: ButtonStyle(
+                        foregroundColor: MaterialStateProperty.all<Color>(
+                          widget.editorProperties.quickCutForegroundColor,
+                        ),
+                        backgroundColor: MaterialStateProperty.all<Color>(
+                          widget.editorProperties.quickCutBackgroundColor,
+                        ),
+                        overlayColor: MaterialStateProperty.all<Color>(
+                          widget.editorProperties.quickCutForegroundColor.withOpacity(0.25),
+                        ),
+                        shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                          RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(35.0),
+                          ),
+                        ),
+                      ),
+                      icon: Icon(
+                        widget.editorProperties.quickCutIcon,
+                        size: widget.editorProperties.quickCutIconSize,
+                      ),
+                      onPressed: () {
+                        _startPos = const Offset(0, 0);
+                        _startFraction = 0.0;
+                        _videoStartPos = 0.0;
+                        _currentPosition = 0;
+                        _linearTween.begin = _startPos.dx;
+
+                        widget.onChangeStart!(_videoStartPos);
+                        videoPlayerController.seekTo(const Duration(milliseconds: 0));
+
+                        _endFraction = (i * 1000) / _videoDuration;
+                        _videoEndPos = _videoDuration * _endFraction;
+                        _endPos = Offset((_endFraction * _thumbnailViewerW), _thumbnailViewerH);
+                        _linearTween.end = _endPos.dx;
+                        widget.onChangeEnd!(_videoEndPos);
+
+                        _animationController!.duration =
+                            Duration(milliseconds: (_videoEndPos - _videoStartPos).toInt());
+                        _animationController!.reset();
+                      },
+                      label: Text(
+                        i.toString(),
+                        style: TextStyle(color: widget.editorProperties.quickCutTextColor),
+                      ),
+                    ),
+                  ),
+              ],
             ),
           ),
         ],

--- a/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
+++ b/lib/src/trim_viewer/fixed_viewer/fixed_trim_viewer.dart
@@ -71,6 +71,8 @@ class FixedTrimViewer extends StatefulWidget {
 
   final VoidCallback onThumbnailLoadingComplete;
 
+  final List<double> quickCutNumbers;
+
   /// Widget for displaying the video trimmer.
   ///
   /// This has frame wise preview of the video with a
@@ -131,6 +133,7 @@ class FixedTrimViewer extends StatefulWidget {
     this.onChangePlaybackState,
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const FixedTrimAreaProperties(),
+    this.quickCutNumbers = const [1, 2, 3, 5, 10],
   });
 
   @override
@@ -173,8 +176,6 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
   Animation<double>? _scrubberAnimation;
   AnimationController? _animationController;
   late Tween<double> _linearTween;
-
-  List<double> quickCutNumber = [1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
   /// Quick access to VideoPlayerController, only not null after [TrimmerEvent.initialized]
   /// has been emitted.
@@ -512,7 +513,7 @@ class _FixedTrimViewerState extends State<FixedTrimViewer>
             physics: const BouncingScrollPhysics(),
             child: Row(
               children: [
-                for (double i in quickCutNumber)
+                for (double i in widget.quickCutNumbers)
                   if (i <= (_videoDuration ~/ 1000))
                     Padding(
                       padding: const EdgeInsets.all(10.0),

--- a/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
+++ b/lib/src/trim_viewer/scrollable_viewer/scrollable_trim_viewer.dart
@@ -471,10 +471,13 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
 
     // log('Local pos: ${details.localPosition}');
     _localPosition = details.localPosition.dx;
+    final double newStartPos = _startPos.dx + _localPosition;
+    final double newEndPos = _endPos.dx + _localPosition;
 
     if (_dragType == EditorDragType.left) {
       _startCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_startPos.dx + details.delta.dx >= 0) &&
+      if ((_endPos.dx - newStartPos >= 100) &&
+          (_startPos.dx + details.delta.dx >= 0) &&
           (_startPos.dx + details.delta.dx <= _endPos.dx) &&
           !(_endPos.dx - _startPos.dx - details.delta.dx > maxLengthPixels!)) {
         _startPos += details.delta;
@@ -492,7 +495,8 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
       }
     } else {
       _endCircleSize = widget.editorProperties.circleSizeOnDrag;
-      if ((_endPos.dx + details.delta.dx <= _thumbnailViewerW) &&
+      if ((newEndPos - _startPos.dx >= 100) &&
+          (_endPos.dx + details.delta.dx <= _thumbnailViewerW) &&
           (_endPos.dx + details.delta.dx >= _startPos.dx) &&
           !(_endPos.dx - _startPos.dx + details.delta.dx > maxLengthPixels!)) {
         _endPos += details.delta;
@@ -589,23 +593,13 @@ class _ScrollableTrimViewerState extends State<ScrollableTrimViewer>
                   child: Padding(
                     padding: const EdgeInsets.only(bottom: 8.0),
                     child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       mainAxisSize: MainAxisSize.max,
                       children: <Widget>[
                         Text(
-                          Duration(milliseconds: _videoStartPos.toInt())
-                              .format(widget.durationStyle),
-                          style: widget.durationTextStyle,
-                        ),
-                        videoPlayerController.value.isPlaying
-                            ? Text(
-                                Duration(milliseconds: _currentPosition.toInt())
-                                    .format(widget.durationStyle),
-                                style: widget.durationTextStyle,
-                              )
-                            : Container(),
-                        Text(
-                          Duration(milliseconds: _videoEndPos.toInt())
+                          Duration(
+                                  milliseconds: _videoEndPos.toInt() -
+                                      _videoStartPos.toInt())
                               .format(widget.durationStyle),
                           style: widget.durationTextStyle,
                         ),

--- a/lib/src/trim_viewer/trim_editor_properties.dart
+++ b/lib/src/trim_viewer/trim_editor_properties.dart
@@ -120,6 +120,6 @@ class TrimEditorProperties {
     this.quickCutTextColor = Colors.white,
     this.quickCutBackgroundColor = Colors.grey,
     this.quickCutForegroundColor = Colors.white70,
-    this.sideTapSize = 24,
+    this.sideTapSize = 25,
   });
 }

--- a/lib/src/trim_viewer/trim_editor_properties.dart
+++ b/lib/src/trim_viewer/trim_editor_properties.dart
@@ -49,6 +49,16 @@ class TrimEditorProperties {
   /// total duration of the video.
   final int sideTapSize;
 
+  final double quickCutIconSize;
+
+  final IconData quickCutIcon;
+
+  final Color quickCutTextColor;
+
+  final Color quickCutBackgroundColor;
+
+  final Color quickCutForegroundColor;
+
   /// Helps defining the Trim Editor properties.
   ///
   /// A better look at the structure of the **Trim Viewer**:
@@ -105,6 +115,11 @@ class TrimEditorProperties {
     this.circlePaintColor = Colors.white,
     this.borderPaintColor = Colors.white,
     this.scrubberPaintColor = Colors.white,
+    this.quickCutIconSize = 20.0,
+    this.quickCutIcon = Icons.cut,
+    this.quickCutTextColor = Colors.white,
+    this.quickCutBackgroundColor = Colors.grey,
+    this.quickCutForegroundColor = Colors.white70,
     this.sideTapSize = 24,
   });
 }

--- a/lib/src/trim_viewer/trim_editor_properties.dart
+++ b/lib/src/trim_viewer/trim_editor_properties.dart
@@ -120,6 +120,6 @@ class TrimEditorProperties {
     this.quickCutTextColor = Colors.white,
     this.quickCutBackgroundColor = Colors.grey,
     this.quickCutForegroundColor = Colors.white70,
-    this.sideTapSize = 25,
+    this.sideTapSize = 22,
   });
 }

--- a/lib/src/trim_viewer/trim_viewer.dart
+++ b/lib/src/trim_viewer/trim_viewer.dart
@@ -90,6 +90,8 @@ class TrimViewer extends StatefulWidget {
   /// thumbnails are loaded.
   final VoidCallback? onThumbnailLoadingComplete;
 
+  final List<double> quickCutNumbers;
+
   /// Widget for displaying the video trimmer.
   ///
   /// This has frame wise preview of the video with a
@@ -184,6 +186,7 @@ class TrimViewer extends StatefulWidget {
     this.editorProperties = const TrimEditorProperties(),
     this.areaProperties = const TrimAreaProperties(),
     this.onThumbnailLoadingComplete,
+    this.quickCutNumbers = const [1, 2, 3, 5, 10],
   });
 
   @override
@@ -263,6 +266,7 @@ class _TrimViewerState extends State<TrimViewer> with TickerProviderStateMixin {
           widget.onThumbnailLoadingComplete!();
         }
       },
+      quickCutNumbers: widget.quickCutNumbers,
     );
 
     return _isScrollableAllowed == null

--- a/lib/src/utils/duration_style.dart
+++ b/lib/src/utils/duration_style.dart
@@ -15,7 +15,13 @@ extension DurationFormatExt on Duration {
     final formatPart = style.toString().split('.')[1].split('_');
     formatPart.removeAt(0);
     // HH_MM_SS
-    final millisecondTime = inMilliseconds;
+    int millisecondTime = inMilliseconds;
+
+    // Check if milliseconds are 990 or greater and adjust millisecondTime to avoid .99 cases
+    if (millisecondTime % 1000 >= 990) {
+      millisecondTime = (millisecondTime ~/ 1000 + 1) * 1000;
+    }
+
     final hoursStr = _getDisplayTimeHours(millisecondTime);
     final mStr = _getDisplayTimeMinute(millisecondTime, hours: true);
     final sStr = _getDisplayTimeSecond(millisecondTime);


### PR DESCRIPTION
This PR is effectively rolling back all the previous commits merged into KyleKun's `video_trimmer` project. This preserve the previous commit history when applying changes on top of the last snapshot of the project from the original sbis04 github in the PR https://github.com/KyleKun/video_trimmer/pull/2

Cherry picked all commits that were previously on KyleKun's video_trimmer which were the following commits:

```
8e3e5f5 Pass quickcut numbers as optional parameter
f3dd2c8 Adds 1.5 quick cut button
8eaf4dc Quick cut restricted to 1s and 1.5s
5fdfb37 Quick cut restricted to 1s and 1.5s
3311af8 Round .99 ms
b8b7bb1 Update left side dragging size allowance
309c0a6 fix dragging for good
523b8a4 Improve dragging
22f4242 Add quick cut
a70c604 Merge branch 'main' of https://github.com/KyleKun/video_trimmer
4ef0684 Do not animate progress bar if video is still buffering
5029aaa Do not animate progress bar if video is still buffering
0f92048 update dependencies
b208d97 Fix when video duration is lower than 10secs
638041e Fix minVideoDuration for fixed viewer
17d98c0 Fix minVideoDuration for fixed viewer
bc6c461 Apply changes to scrollable trimmer
dbb0349 Fix 1sec value
4cd7f30 Do not allow trim if it's less than a second
7044e41 Show only selected duration
```

Of note: wherever there were changes to `example` directory and there was a merge conflict I simply focused on properly merging all code is `src` directory and completely omitted changes in `example` dir.